### PR TITLE
Make the new keyword optional.

### DIFF
--- a/set.js
+++ b/set.js
@@ -43,6 +43,7 @@ var value = true
   }
 
 var Set = function(input){
+  if (!(this instanceof Set)) return new Set(input)
   this._set = unique(input || [])
 }
 

--- a/test/set-test.js
+++ b/test/set-test.js
@@ -195,5 +195,21 @@ vows.describe('Set').addBatch({
             }
         }
     }
+
+    , "Initialized with [0,1,2,3,4] without the new keyword": {
+        topic: Set([0, 1, 2, 3, 4])
+
+        , "will be a Set": function(topic){
+            assert.instanceOf(topic, Set)
+        }
+
+        , "is not empty": function(topic){
+            assert.isFalse(topic.empty())
+        }
+
+        , "contains a 0": function(topic){
+            assert.isTrue(topic.contains(0))
+        }
+    }
 }
 }).export(module)


### PR DESCRIPTION
Hey! Great module!

This PR makes the `new` keyword optional, so that you can do stuff like this.

``` js
var set = require('set');
var colors = set(['red', 'blue', 'green']);
```

This also prevents the module from modifying global state if someone forgets the new keyword.
